### PR TITLE
Added spellcheck to the list of inherited input attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
 
+*  Added `spellcheck` to the list of `input` attributes that are inherited by selectize.
+
+   *@winzig*
+
 *  Fixed bug making `clearOptions` function. Now it doesn't remove already selected options.
 
    *(thanks @caseymct - #1079)*

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -178,6 +178,10 @@ $.extend(Selectize.prototype, {
 		if ($input.attr('autocapitalize')) {
 			$control_input.attr('autocapitalize', $input.attr('autocapitalize'));
 		}
+
+		if ($input.attr('spellcheck')) {
+			$control_input.attr('spellcheck', $input.attr('spellcheck'));
+		}
 		$control_input[0].type = $input[0].type;
 
 		self.$wrapper          = $wrapper;

--- a/test/setup.js
+++ b/test/setup.js
@@ -47,14 +47,16 @@
 			});
 			describe('<input type="text" attributes>', function() {
 				it('should propagate original input attributes to the generated input', function() {
-					var test = setup_test('<input type="text" autocorrect="off" autocapitalize="none">', {});
+					var test = setup_test('<input type="text" autocorrect="off" autocapitalize="none" spellcheck="false">', {});
 					expect(test.selectize.$control_input.attr('autocorrect')).to.be.equal('off');
 					expect(test.selectize.$control_input.attr('autocapitalize')).to.be.equal('none');
+					expect(test.selectize.$control_input.attr('spellcheck')).to.be.equal('false');
 				});
 				it('should not add attributes if not present in the original', function() {
 					var test = setup_test('<input type="text">', {});
 					expect(test.selectize.$control_input.attr('autocorrect')).to.be.equal(undefined);
 					expect(test.selectize.$control_input.attr('autocapitalize')).to.be.equal(undefined);
+					expect(test.selectize.$control_input.attr('spellcheck')).to.be.equal(undefined);
 				});
 			});
 		});


### PR DESCRIPTION
We now inherit `spellcheck` attributes, just as it inherits the `autocorrect` and `autocapitalize` attributes from input elements. Especially helpful in Safari.

Fixes issue raised in https://github.com/selectize/selectize.js/issues/1403