### PR TITLE
Avoid calling createItem twice. Fixes #1001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
 
+*  Fixed bug that can call `createItem` twice when tab is used.
+
+   *@cerdiogenes* 
+
 *  Added `spellcheck` to the list of `input` attributes that are inherited by selectize.
 
    *@winzig*

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -538,7 +538,7 @@ $.extend(Selectize.prototype, {
 						e.preventDefault();
 					}
 				}
-				if (self.settings.create && self.createItem()) {
+				else if (self.settings.create && self.createItem()) {
 					e.preventDefault();
 				}
 				return;


### PR DESCRIPTION
Incorporating change from PR https://github.com/selectize/selectize.js/pull/1054 which was never merged.